### PR TITLE
Document freemium Pro monetization strategy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Start here. These pages capture **product intent** and **technical decisions** s
 | [map-and-location.md](map-and-location.md) | MapKit UI (camera, zoom), Core Location permissions, and planning coordinates. |
 | [walking-pace.md](walking-pace.md) | Personalized walking speed (Health, saved walks), `planLoop` wiring, **simulator Health fixtures**, testing. |
 | [in-app-navigation.md](in-app-navigation.md) | Turn-by-turn after **Start**, step progression, chase camera, completion → History. |
+| [monetization.md](monetization.md) | Freemium / Pro unlock recommendation, pricing posture, and models to avoid. |
 | [build-and-test.md](build-and-test.md) | Commands for generating the project, building, and running core tests. |
 | [code-conventions.md](code-conventions.md) | Where to put logic, testing expectations, and documentation style in source. |
 

--- a/docs/monetization.md
+++ b/docs/monetization.md
@@ -1,0 +1,60 @@
+# Monetization
+
+Random Walker should monetize in a way that preserves the product's calm, privacy-forward walking experience. The best fit is a **freemium app with a one-time Pro unlock**: casual walkers can use the core loop generator for free, while habitual walkers can pay for features that deepen history, watch use, route control, and personal insights.
+
+## Recommended model
+
+Use a **free core app** plus a **Pro unlock**.
+
+### Free
+
+- Generate random walking loops that return to the start.
+- Start in-app walking guidance on iPhone.
+- Save a small amount of recent walk history.
+- Use basic route regeneration.
+
+### Pro
+
+- Unlimited walk history.
+- Apple Watch navigation and path recording features.
+- Custom walking time and route distance goals.
+- More route-generation controls, such as avoiding repetition or favoring exploratory routes when feasible.
+- Advanced personal stats, such as pace trends, distance totals, streaks, and explored-area summaries.
+- Export saved walks, for example GPX or GeoJSON.
+
+## Pricing posture
+
+A one-time Pro unlock is the default recommendation because Random Walker is primarily a personal utility. It avoids subscription fatigue and fits the app's trust-oriented Apple-platform design.
+
+Reasonable starting price ranges:
+
+- One-time Pro unlock: **$9.99-$19.99**.
+- Optional subscription only if ongoing services are added later: **$1.99-$3.99/month** or **$14.99-$29.99/year**.
+
+Subscriptions should be reserved for features that create recurring operating cost or ongoing value, such as cloud sync, shared route collections, collaborative walking challenges, or regularly refreshed local content.
+
+## Secondary options
+
+### Paid upfront
+
+A paid app can work if the positioning is simple and premium: "a delightful walking-route generator for people who want to explore their city." This is easy to operate, but it reduces trial conversion because users cannot experience route quality before paying.
+
+### Tip jar or supporter purchases
+
+Optional tips can complement the free or Pro model. They preserve goodwill and are simple to implement, but they should not be the main revenue expectation.
+
+### Local partnerships
+
+Local walking themes, tourism-board packs, or business-sponsored discovery routes may fit the exploration concept later. Treat this as an experiment because it adds operational complexity and can make the product feel less private if introduced too early.
+
+## Models to avoid
+
+- **Ads**: poor fit for an outdoor navigation experience and likely to undermine the app's calm feel.
+- **Selling or sharing location data**: incompatible with a product built around personal walks, HealthKit-adjacent pace data, and trust in Apple-native privacy expectations.
+- **Per-route charges**: discourages exploration and route regeneration, which are central to the product.
+
+## Positioning
+
+Use a simple message:
+
+> Random Walker is free for casual walks. Pro is for people who make walking a habit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a new monetization doc recommending a freemium app with a one-time Pro unlock.
- Capture free vs Pro feature boundaries, pricing posture, secondary options, and models to avoid.
- Link the new page from the developer documentation index.

## Verification
- `python3 - <<'PY' ... PY` documentation verification script confirmed the new page exists, has a single heading, includes the recommended model, and is linked from `docs/index.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7418c17e-83fa-45c2-8e1d-524f09f1398b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7418c17e-83fa-45c2-8e1d-524f09f1398b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

